### PR TITLE
CI: Publish npm package to registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@5.2.0
+
 jobs:
   publish:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,16 @@ workflows:
     jobs:
       - require_approval:
           type: approval
-            #filters:
-            #  branches:
-            #    only:
-            #      - main
+          filters:
+            branches:
+              only:
+                - main
       - publish:
           requires:
             - require_approval
           filters:
             tags:
               only: /.*/
-                #            branches:
-                #              only:
-                #                - main
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,14 @@ version: 2.1
 
 jobs:
   publish:
-    docker:
-      - image: circleci/node
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
     steps:
       - checkout
-      - run:
-          name: Install requirements
-          command: npm install prettier
+      - node/install:
+          install-yarn: true
+          node-version: '21.7'
       - run:
           name: Auth With NPM
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install npm
-          command: npm install
-      - run:
           name: Auth With NPM
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              only:
-                - main
+                #            branches:
+                #              only:
+                #                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: Publish to NPM
-          command: npm publish
+          command: |
+            npm install
+            npm publish
 
 workflows:
   CI:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+jobs:
+  publish:
+    docker:
+      - image: circleci/node
+    steps:
+      - checkout
+      - run:
+          name: Install npm
+          command: npm install
+      - run:
+          name: Auth With NPM
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+      - run:
+          name: Publish to NPM
+          command: npm publish
+
+workflows:
+  CI:
+    jobs:
+      - publish:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install requirements
+          command: npm install prettier
+      - run:
           name: Auth With NPM
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,17 @@ orbs:
 jobs:
   publish:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
       resource_class: large
     steps:
       - checkout
       - node/install:
-          install-yarn: true
           node-version: '21.7'
       - run:
-          name: Auth With NPM
+          name: Auth With NPM registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
-          name: Publish to NPM
+          name: Install requirements and publish package
           command: |
             npm install
             npm publish
@@ -25,7 +24,15 @@ jobs:
 workflows:
   CI:
     jobs:
+      - require_approval:
+          type: approval
+            #filters:
+            #  branches:
+            #    only:
+            #      - main
       - publish:
+          requires:
+            - require_approval
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - node/install:
           node-version: '21.7'
       - run:
-          name: Auth With NPM registry
+          name: Authenticate with NPM registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: Install requirements and publish package

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <p align="center"><strong>TypeScript</strong> library</p>
     <p align="center">
         <a href="https://github.com/babylonchain/btc-staking-ts/releases">
-            <img src="https://img.shields.io/badge/version-0.1.0-FF7C2B">
+            <img src="https://img.shields.io/badge/version-0.1.1-FF7C2B">
         </a>
     </p>
 </p>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <p align="center"><strong>TypeScript</strong> library</p>
     <p align="center">
         <a href="https://github.com/babylonchain/btc-staking-ts/releases">
-            <img src="https://img.shields.io/badge/version-0.0.1-FF7C2B">
+            <img src="https://img.shields.io/badge/version-0.1.0-FF7C2B">
         </a>
     </p>
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-staking-ts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol. Experimental version, should not be used for production purposes or with real funds.",
   "module": "dist/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-staking-ts",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol. Experimental version, should not be used for production purposes or with real funds.",
   "module": "dist/index.js",
   "main": "dist/index.js",


### PR DESCRIPTION
Add a job that authenticates with babylonchain NPM org and publishes a package. The job requires manual approval.

https://www.npmjs.com/package/btc-staking-ts

NOTE: Due to some experimentation, we'll have to publish the package under v0.1.1. Previous versions have been unpublished and NPM registry is immutable, so we can't publish them again.