### PR TITLE
feature: OP_NUMEQUAL OP_NUMEQUALVERIFY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-staking-ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol. Experimental version, should not be used for production purposes or with real funds.",
   "module": "dist/index.js",
   "main": "dist/index.js",

--- a/src/utils/stakingScript.ts
+++ b/src/utils/stakingScript.ts
@@ -256,8 +256,8 @@ export class StakingScriptData {
 
   /**
    * Builds a multi-key script in the form:
-   *    <pk1> OP_CHEKCSIG <pk2> OP_CHECKSIGADD <pk3> OP_CHECKSIGADD ... <pkN> OP_CHECKSIGADD <threshold> OP_GREATERTHANOREQUAL
-   *    <withVerify -> OP_VERIFY>
+   *    <pk1> OP_CHEKCSIG <pk2> OP_CHECKSIGADD <pk3> OP_CHECKSIGADD ... <pkN> OP_CHECKSIGADD <threshold> OP_NUMEQUAL
+   *    <withVerify -> OP_NUMEQUALVERIFY>
    * It validates whether provided keys are unique and the threshold is not greater than number of keys
    * If there is only one key provided it will return single key sig script
    * @param pks - An array of public keys.
@@ -302,9 +302,10 @@ export class StakingScriptData {
       scriptElements.push(opcodes.OP_CHECKSIGADD);
     }
     scriptElements.push(script.number.encode(threshold));
-    scriptElements.push(opcodes.OP_GREATERTHANOREQUAL);
     if (withVerify) {
-      scriptElements.push(opcodes.OP_VERIFY);
+      scriptElements.push(opcodes.OP_NUMEQUALVERIFY);
+    } else {
+      scriptElements.push(opcodes.OP_NUMEQUAL);
     }
     return script.compile(scriptElements);
   }


### PR DESCRIPTION
- Whenever we used `OP_GREATERTHANOREQUAL` when building scripts we should now use `OP_NUMEQUAL `
- And wherever we used `OP_GREATERTHANOREQUAL` followed by `OP_VERIFY` we should use `OP_NUMEQUALVERIFY`
