### PR TITLE
Fee rate based calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,28 +346,21 @@ There are two types of slashing transactions:
 1. Slashing of the staking transaction when no unbonding has been performed:
 
 ```ts
-import { Taptree } from "bitcoinjs-lib/src/types";
-import { slashingTransaction } from "btc-staking-ts";
+import { slashingNoUnbondingTransaction } from "btc-staking-ts";
 import { Psbt, Transaction } from "bitcoinjs-lib";
-
-const slashingScriptTree: Taptree = [
-  {
-    output: slashingScript,
-  },
-  [{ output: unbondingScript }, { output: timelockScript }],
-];
 
 const outputIndex: number = 0;
 
-const unsignedSlashingPsbt: {psbt: Psbt} = slashingTransaction(
+const unsignedSlashingPsbt: {psbt: Psbt} = slashingNoUnbondingTransaction(
   scripts: {
     slashingScript,
+    unbondingScript,
+    timelockScript,
+    unbondingTimelockScript,
   },
-  slashingScriptTree,
   stakingTx,
   slashingAddress,
   slashingRate,
-  unbondingTimelockScript,
   minimumSlashingFee,
   network,
   outputIndex,
@@ -379,32 +372,23 @@ const slashingTx = Psbt.fromHex(signedPsbt).extractTransaction();
 
 2. Slashing of the unbonding transaction in the case of on-demand unbonding:
 
-```ts
-const unbondingScriptTree: Taptree = [
-  {
-    output: slashingScript,
-  },
-  { output: unbondingTimelockScript },
-];
-```
-
-Then create unsigned unbonding slashing transaction
+create unsigned unbonding slashing transaction
 
 ```ts
 import { Psbt, Transaction } from "bitcoinjs-lib";
-import { slashingTransaction } from "btc-staking-ts";
+import { slashOnDemandUnbondingTransaction } from "btc-staking-ts";
 
 const outputIndex: number = 0;
 
-const unsignedUnbondingSlashingPsbt: {psbt: Psbt} = slashingTransaction(
+const unsignedUnbondingSlashingPsbt: {psbt: Psbt} = slashOnDemandUnbondingTransaction(
   scripts: {
     slashingScript,
+    unbondingTimelockScript,
   },
   unbondingScriptTree,
   unbondingTx,
   slashingAddress,
   slashingRate,
-  unbondingTimelockScript,
   minimumSlashingFee,
   network,
   outputIndex

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-staking-ts",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol. Experimental version, should not be used for production purposes or with real funds.",
   "module": "dist/index.js",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export { initBTCCurve, StakingScriptData };
 // https://bips.xyz/370
 const BTC_LOCKTIME_HEIGHT_TIME_CUTOFF = 500000000;
 
+const BTC_DUST_SAT = 546;
+
 export interface PsbtTransactionResult {
   psbt: Psbt;
   fee: number;
@@ -128,7 +130,7 @@ export function stakingTransaction(
   }
 
   // Add a change output only if there's any amount leftover from the inputs
-  if (inputsSum > amount + fee) {
+  if ((inputsSum + BTC_DUST_SAT) > (amount + fee)) {
     psbt.addOutput({
       address: changeAddress,
       value: inputsSum - (amount + fee),

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,8 +152,8 @@ export function withdrawEarlyUnbondedTransaction(
   },
   tx: Transaction,
   withdrawalAddress: string,
-  feeRate: number,
   network: networks.Network,
+  feeRate: number,
   outputIndex: number = 0,
 ): {
   psbt: Psbt,
@@ -406,16 +406,15 @@ export function unbondingTransaction(
     slashingScript: Buffer,
   },
   stakingTx: Transaction,
+  transactionFee: number,
   network: networks.Network,
-  feeRate: number,
   outputIndex: number = 0,
 ): {
-  psbt: Psbt,
-  fee: number
+  psbt: Psbt
 } {
   // Check that transaction fee is bigger than 0
-  if (feeRate <= 0) {
-    throw new Error("Unbonding feeRate must be bigger than 0");
+  if (transactionFee <= 0) {
+    throw new Error("Unbonding fee must be bigger than 0");
   }
 
   // Check that outputIndex is bigger or equal to 0
@@ -475,9 +474,6 @@ export function unbondingTransaction(
     network,
   });
 
-  const outputSize = psbt.txOutputs.length + 1
-  const transactionFee = getEstimatedFee(feeRate, psbt.txInputs.length, outputSize);
-
   // Add the unbonding output
   psbt.addOutput({
     address: unbondingOutput.address!,
@@ -485,8 +481,7 @@ export function unbondingTransaction(
   });
 
   return {
-    psbt,
-    fee: transactionFee
+    psbt
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ const getStakingTxInputUTXOsAndFees = (
 //     and dataEmbedScript: Optional data embed script
 //   - amount, fee: Amount to stake and transaction fee
 //   - changeAddress: Address to send the change to
-//   - inputUTXOs: UTXOs to use as inputs for the transaction
+//   - inputUTXOs: all available UTXOs from the wallet
 //   - network: Bitcoin network
 //   - publicKeyNoCoord: Public key if the wallet is in taproot mode
 //   - lockHeight: Optional block height locktime to set for the transaction. i.e not mined until block height

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ const getStakingTxInputUTXOsAndFees = (
   if (availableUTXOs.length === 0) {
     throw new Error("Insufficient funds");
   }
+  // Sort available UTXOs from highest to lowest value
+  availableUTXOs.sort((a, b) => b.value - a.value);
 
   let selectedUTXOs: UTXO[] = [];
   let accumulatedValue = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,32 @@ export function stakingTransaction(
   };
 }
 
-// Delegation is manually unbonded
+/**
+ * Constructs a withdrawal transaction for manually unbonded delegation.
+ *
+ * This transaction spends the unbonded output from the staking transaction.
+ *
+ * Inputs:
+ * - scripts: Various scripts used in the transaction.
+ *   - unbondingTimelockScript: Script for the unbonding timelock condition.
+ *   - slashingScript: Script for the slashing condition.
+ * - tx: The original staking transaction.
+ * - withdrawalAddress: The address to send the withdrawn funds to.
+ * - network: The Bitcoin network.
+ * - feeRate: The fee rate for the transaction in satoshis per byte.
+ * - outputIndex: The index of the output to be spent in the original transaction (default is 0).
+ *
+ * Returns:
+ * - psbt: The partially signed transaction (PSBT).
+ *
+ * @param {Object} scripts - The scripts used in the transaction.
+ * @param {Transaction} tx - The original staking transaction.
+ * @param {string} withdrawalAddress - The address to send the withdrawn funds to.
+ * @param {networks.Network} network - The Bitcoin network.
+ * @param {number} feeRate - The fee rate for the transaction in satoshis per byte.
+ * @param {number} [outputIndex=0] - The index of the output to be spent in the original transaction.
+ * @returns {PsbtTransactionResult} An object containing the partially signed transaction (PSBT).
+ */
 export function withdrawEarlyUnbondedTransaction(
   scripts: {
     unbondingTimelockScript: Buffer,
@@ -196,7 +221,33 @@ export function withdrawEarlyUnbondedTransaction(
   );
 }
 
-// Delegation is naturally unbonded
+/**
+ * Constructs a withdrawal transaction for naturally unbonded delegation.
+ *
+ * This transaction spends the unbonded output from the staking transaction when the timelock has expired.
+ *
+ * Inputs:
+ * - scripts: Various scripts used in the transaction.
+ *   - timelockScript: Script for the timelock condition.
+ *   - slashingScript: Script for the slashing condition.
+ *   - unbondingScript: Script for the unbonding condition.
+ * - tx: The original staking transaction.
+ * - withdrawalAddress: The address to send the withdrawn funds to.
+ * - network: The Bitcoin network.
+ * - feeRate: The fee rate for the transaction in satoshis per byte.
+ * - outputIndex: The index of the output to be spent in the original transaction (default is 0).
+ *
+ * Returns:
+ * - psbt: The partially signed transaction (PSBT).
+ *
+ * @param {Object} scripts - The scripts used in the transaction.
+ * @param {Transaction} tx - The original staking transaction.
+ * @param {string} withdrawalAddress - The address to send the withdrawn funds to.
+ * @param {networks.Network} network - The Bitcoin network.
+ * @param {number} feeRate - The fee rate for the transaction in satoshis per byte.
+ * @param {number} [outputIndex=0] - The index of the output to be spent in the original transaction.
+ * @returns {PsbtTransactionResult} An object containing the partially signed transaction (PSBT).
+ */
 export function withdrawTimelockUnbondedTransaction(
   scripts: {
     timelockScript: Buffer,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,9 @@
+import { Psbt } from "bitcoinjs-lib";
+
+// PsbtTransactionResult is the result of a transaction creation
+//  - psbt: The partially signed transaction
+//  - fee: The total fee of the transaction
+export interface PsbtTransactionResult {
+    psbt: Psbt;
+    fee: number;
+}

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -1,0 +1,18 @@
+// Estimated size of a transaction input in bytes for fee calculation purpose only
+export const INPUT_SIZE_FOR_FEE_CAL = 180;
+
+// Estimated size of a transaction output in bytes for fee calculation purpose only
+export const OUTPUT_SIZE_FOR_FEE_CAL = 34;
+
+// Buffer size for a transaction in bytes for fee calculation purpose only
+export const TX_BUFFER_SIZE_FOR_FEE_CAL = 10;
+
+export const getEstimatedFee = (
+    feeRate: number, numInputs: number, numOutputs: number,
+): number => {
+    return (
+        numInputs * INPUT_SIZE_FOR_FEE_CAL +
+        numOutputs * OUTPUT_SIZE_FOR_FEE_CAL +
+        TX_BUFFER_SIZE_FOR_FEE_CAL + numInputs
+    ) * feeRate;
+}

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -9,15 +9,110 @@ export const OUTPUT_SIZE_FOR_FEE_CAL = 34;
 // Buffer size for a transaction in bytes for fee calculation purpose only
 export const TX_BUFFER_SIZE_FOR_FEE_CAL = 10;
 
+export const ESTIMATED_OP_RETURN_SIZE = 40;
+
+/**
+ * Calculates the estimated transaction fee using a heuristic formula.
+ *
+ * This method estimates the transaction fee based on the formula:
+ * `numInputs * 180 + numOutputs * 34 + 10 + numInputs`
+ *
+ * The formula provides an overestimated transaction size to ensure sufficient fees:
+ * - Each input is approximated to 180 bytes.
+ * - Each output is approximated to 34 bytes.
+ * - Adds 10 bytes as a buffer for the transaction.
+ * - Adds 40 bytes for an OP_RETURN output.
+ * - Adds the number of inputs to account for additional overhead.
+ *
+ * @param feeRate - The fee rate in satoshis per byte.
+ * @param numInputs - The number of inputs in the transaction.
+ * @param numOutputs - The number of outputs in the transaction.
+ * @returns The estimated transaction fee in satoshis.
+ */
 export const getEstimatedFee = (
     feeRate: number, numInputs: number, numOutputs: number,
 ): number => {
     return (
         numInputs * INPUT_SIZE_FOR_FEE_CAL +
         numOutputs * OUTPUT_SIZE_FOR_FEE_CAL +
-        TX_BUFFER_SIZE_FOR_FEE_CAL + numInputs
+        TX_BUFFER_SIZE_FOR_FEE_CAL + numInputs + ESTIMATED_OP_RETURN_SIZE
     ) * feeRate;
 }
+
+// inputValueSum returns the sum of the values of the UTXOs
 export const inputValueSum = (inputUTXOs: UTXO[]): number => {
     return inputUTXOs.reduce((acc, utxo) => acc + utxo.value, 0);
+}
+
+// getStakingTxInputUTXOsAndFees returns the selected UTXOs and the fee for the staking transaction
+// by selecting the UTXOs with the highest value that can cover the staking amount and fees
+// - availableUTXOs: All available UTXOs from the wallet
+// - stakingAmount: Amount to stake
+// - feeRate: Fee rate for the transaction
+// - numOfOutputs: Number of outputs in the transaction
+// Returns:
+// - selectedUTXOs: The selected UTXOs to cover the staking amount and fees
+// - fee: The total fee amount of the transaction
+/**
+ * Selects UTXOs and calculates the fee for a staking transaction.
+ *
+ * This method selects the highest value UTXOs from all available UTXOs to 
+ * cover the staking amount and the transaction fees.
+ *
+ * Inputs:
+ * - availableUTXOs: All available UTXOs from the wallet.
+ * - stakingAmount: Amount to stake.
+ * - feeRate: Fee rate for the transaction in satoshis per byte.
+ * - numOfOutputs: Number of outputs in the transaction.
+ *
+ * Returns:
+ * - selectedUTXOs: The UTXOs selected to cover the staking amount and fees.
+ * - fee: The total fee amount for the transaction.
+ *
+ * @param {UTXO[]} availableUTXOs - All available UTXOs from the wallet.
+ * @param {number} stakingAmount - The amount to stake.
+ * @param {number} feeRate - The fee rate in satoshis per byte.
+ * @param {number} numOfOutputs - The number of outputs in the transaction.
+ * @returns {PsbtTransactionResult} An object containing the selected UTXOs and the fee.
+ * @throws Will throw an error if there are insufficient funds or if the fee cannot be calculated.
+ */
+export const getStakingTxInputUTXOsAndFees = (
+    availableUTXOs: UTXO[],
+    stakingAmount: number,
+    feeRate: number,
+    numOfOutputs: number,
+): {
+    selectedUTXOs: UTXO[],
+    fee: number,
+} => {
+    if (availableUTXOs.length === 0) {
+        throw new Error("Insufficient funds");
+    }
+    // Sort available UTXOs from highest to lowest value
+    availableUTXOs.sort((a, b) => b.value - a.value);
+
+    let selectedUTXOs: UTXO[] = [];
+    let accumulatedValue = 0;
+    let estimatedFee;
+
+    for (const utxo of availableUTXOs) {
+        selectedUTXOs.push(utxo);
+        accumulatedValue += utxo.value;
+        estimatedFee = getEstimatedFee(feeRate, selectedUTXOs.length, numOfOutputs);
+        if (accumulatedValue >= stakingAmount + estimatedFee) {
+            break;
+        }
+    }
+    if (!estimatedFee) {
+        throw new Error("Unable to calculate fee.");
+    }
+
+    if (accumulatedValue < stakingAmount + estimatedFee) {
+        throw new Error("Insufficient funds: unable to gather enough UTXOs to cover the staking amount and fees.");
+    }
+
+    return {
+        selectedUTXOs,
+        fee: estimatedFee,
+    };
 }

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -9,6 +9,7 @@ export const OUTPUT_SIZE_FOR_FEE_CAL = 34;
 // Buffer size for a transaction in bytes for fee calculation purpose only
 export const TX_BUFFER_SIZE_FOR_FEE_CAL = 10;
 
+// Estimated size of an OP_RETURN output in bytes for fee calculation purpose only
 export const ESTIMATED_OP_RETURN_SIZE = 40;
 
 /**
@@ -44,15 +45,6 @@ export const inputValueSum = (inputUTXOs: UTXO[]): number => {
     return inputUTXOs.reduce((acc, utxo) => acc + utxo.value, 0);
 }
 
-// getStakingTxInputUTXOsAndFees returns the selected UTXOs and the fee for the staking transaction
-// by selecting the UTXOs with the highest value that can cover the staking amount and fees
-// - availableUTXOs: All available UTXOs from the wallet
-// - stakingAmount: Amount to stake
-// - feeRate: Fee rate for the transaction
-// - numOfOutputs: Number of outputs in the transaction
-// Returns:
-// - selectedUTXOs: The selected UTXOs to cover the staking amount and fees
-// - fee: The total fee amount of the transaction
 /**
  * Selects UTXOs and calculates the fee for a staking transaction.
  *

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -1,3 +1,5 @@
+import { UTXO } from "../types/UTXO";
+
 // Estimated size of a transaction input in bytes for fee calculation purpose only
 export const INPUT_SIZE_FOR_FEE_CAL = 180;
 
@@ -15,4 +17,7 @@ export const getEstimatedFee = (
         numOutputs * OUTPUT_SIZE_FOR_FEE_CAL +
         TX_BUFFER_SIZE_FOR_FEE_CAL + numInputs
     ) * feeRate;
+}
+export const inputValueSum = (inputUTXOs: UTXO[]): number => {
+    return inputUTXOs.reduce((acc, utxo) => acc + utxo.value, 0);
 }


### PR DESCRIPTION
**This is a breaking change to all methods**

While making the feeRate change (which had to be a breaking change anyway), i would also like to include some other breaking changes such as putting all scripts under the "scripts" field, and make the return type as object.

1. Changed from fixed fee to feeRate based calculation for staking and withdraw methods
2. Change all methods inputs shape. moved all scripts under a single `scripts` field.
3. Change all return type from a single psbt to a object which include the psbt for better extensibility
4. `slashingTransaction` is now private method