### PR TITLE
feature: Unbonding always has a single output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-staking-ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol. Experimental version, should not be used for production purposes or with real funds.",
   "module": "dist/index.js",
   "main": "dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export function withdrawEarlyUnbondedTransaction(
   withdrawalAddress: string,
   network: networks.Network,
   feeRate: number,
-  outputIndex: number = 0,
+  _outputIndex: number = 0,
 ): PsbtTransactionResult {
   const scriptTree: Taptree = [
     {
@@ -217,7 +217,7 @@ export function withdrawEarlyUnbondedTransaction(
     withdrawalAddress,
     network,
     feeRate,
-    outputIndex,
+    0, // unbonding always has a single output
   );
 }
 


### PR DESCRIPTION
Withdrawal of manually unbonded txes always passes 0 as an output, even when staking transaction has different output