### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,9 +337,9 @@ const unbondingTx: Transaction = undefined;
 const unsignedWithdrawalPsbt: {psbt: Psbt, fee: number} = withdrawEarlyUnbondedTransaction(
   scripts: {
     unbondingTimelockScript,
-    slashingScript,
-    unbondingTx,  
+    slashingScript,   
   },
+  unbondingTx, 
   withdrawalAddress,
   network,
   feeRate,


### PR DESCRIPTION
Based on the code, this looks wrong:
https://github.com/babylonchain/btc-staking-ts/blob/main/src/index.ts#L167-L177